### PR TITLE
make boulders spawn given 'per second' frequency

### DIFF
--- a/Assets/Scenes/Arena.unity
+++ b/Assets/Scenes/Arena.unity
@@ -1135,6 +1135,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 535f61773523b0a4499714271bbb5958, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  walkEnemyAmt: 0
+  jumpEnemyAmt: 0
+  rangedEnemyAmt: 0
+  spikeTrapAmt: 0
+  boulderFreq: 0
 --- !u!1 &438181570
 GameObject:
   m_ObjectHideFlags: 0
@@ -1567,7 +1572,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   compositeCollider: {fileID: 0}
-  numberOfEnemies: 5
   enemies: []
   Enemy1: {fileID: 1844930401815919459, guid: a80e49bbb4d41e6438fecc5eafae4284, type: 3}
 --- !u!114 &538684458
@@ -1583,11 +1587,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   compositeCollider: {fileID: 0}
-  numberOfSpikeTraps: 5
   traps: []
   boulders: []
-  boulderFreq: 1
-  waiting: 300
   TrapPrefab: {fileID: 139402092358131914, guid: 0dd1f9877a7fe441e83822d136824985, type: 3}
   BoulderPrefab: {fileID: 6200978371782180327, guid: 7e38f7c2051204ed8aaa3267b58bb068, type: 3}
 --- !u!66 &538684459
@@ -5265,6 +5266,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bd8b752759cb20244a6276ab1d78cd05, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  walkEnemyAmt: 1
+  jumpEnemyAmt: 1
+  rangedEnemyAmt: 1
+  spikeTrapAmt: 1
+  boulderFreq: 1
   playerLevel: 1
   playerHealth: 100
   playerMaxHealth: 101

--- a/Assets/Scripts/ArenaManager.cs
+++ b/Assets/Scripts/ArenaManager.cs
@@ -9,7 +9,7 @@ public class ArenaManager : MonoBehaviour
   public int jumpEnemyAmt;
   public int rangedEnemyAmt;
   public int spikeTrapAmt;
-  public float boulderFreq;
+  public double boulderFreq;
 
   //GameManager reference
   private GameObject gameManager;

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -16,7 +16,7 @@ public class GameManager : MonoBehaviour
   public int jumpEnemyAmt;
   public int rangedEnemyAmt;
   public int spikeTrapAmt;
-  public float boulderFreq;
+  public double boulderFreq;
 
   // Player stats that persist through levels
   public int playerLevel = 1;
@@ -29,11 +29,8 @@ public class GameManager : MonoBehaviour
 //     public float expMultiplier = 1.8f;
 //     public int playerExp = 0;
 //     public int playerExpToNext = 10;
-
 //     public string currentRoom;
-
 //     //private bool doingSetup = true;
-
 
   //Awake is always called before any Start functions
   void Awake()
@@ -84,13 +81,10 @@ public class GameManager : MonoBehaviour
     arenaManager.SetupScene(floorLevel);
   }
 
-
-
 //     public void GameOver()
 //     {
 //         enabled = false;
 //     }
-
 
   //Update is called every frame.
   void Update()

--- a/Assets/Scripts/TrapManager.cs
+++ b/Assets/Scripts/TrapManager.cs
@@ -7,41 +7,43 @@ public class TrapManager : MonoBehaviour
 {
     //arena setup parameters
     private int spikeTrapAmt;
-    public float boulderFreq = 1f; //how many boulders per x (not in use)
-    public static float waiting = 500f; //every x frames
-    public float initWait = waiting;
+    private double boulderFreq; //how many boulders per second
 
     private ArenaManager arenaManager;
+    private float time = 0f;
+    private float frequency = 0;
     public CompositeCollider2D compositeCollider;
     public List<GameObject> traps;
     public List<GameObject> boulders;
-
     public GameObject TrapPrefab;
     public GameObject BoulderPrefab;
 
     void Start()
     {
-        arenaManager = GameObject.Find("ArenaManager").GetComponent<ArenaManager>();
-        compositeCollider = gameObject.GetComponent<CompositeCollider2D>();
-        traps = new List<GameObject>();
-        spawnSpikeTraps();
+      arenaManager = GameObject.Find("ArenaManager").GetComponent<ArenaManager>();
+      compositeCollider = gameObject.GetComponent<CompositeCollider2D>();
+      traps = new List<GameObject>();
+      Debug.Log(boulderFreq);
+      boulderFreq = arenaManager.boulderFreq;
+      if (boulderFreq > 0)
+      {
+        frequency = (float)1/(float)boulderFreq;
+        Debug.Log(frequency);
+      }
+      spawnSpikeTraps();
     }
 
     void Update()
     {
-        //spawn boulder IF IT MAKES SENSE IN CURRENT GAME STATE (still fighting enemies)
-        bool inPlay = true; //placeholder for game state decision
-        if (inPlay)
+      if (frequency != 0)
+      {
+        time += Time.deltaTime;
+        if (time >= frequency)
         {
-          //must determine how frequently to drop boulder
-          //PLACEHOLDER
-          waiting--;
-          if (waiting < 1)
-          {
-            waiting = initWait;
-            spawnBoulder();
-          }
+          spawnBoulder();
+          time = 0f;
         }
+      }
     }
 
     private void spawnBoulder()


### PR DESCRIPTION
game manager has boulder frequency parameter determining how fast to spawn boulders in the update function
parameter represents how many boulders per second

for example
freq = 5 means 5 boulders spawn per second on the arena
freq = 0.2 means 1 boulder spawns every 5 seconds on the arena